### PR TITLE
Refresh profile README: showcase open-source contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <a href="https://linkedin.com/in/patrick-wehbe">
-  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=720&lines=Hi%2C+I'm+Patrick+Wehbe+%F0%9F%91%8B;Full-Stack+Engineer+%E2%80%A2+Beirut%2C+Lebanon;React+%E2%80%A2+TypeScript+%E2%80%A2+Node+%E2%80%A2+DevOps;Shipping+products+at+scale+since+2019" alt="typing-banner" />
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=720&lines=Hi%2C+I'm+Patrick+Wehbe+%F0%9F%91%8B;Full-Stack+Engineer+%E2%80%A2+Beirut%2C+Lebanon;React+%E2%80%A2+TypeScript+%E2%80%A2+Node+%E2%80%A2+DevOps;Open-source+contributor+across+30%2B+projects" alt="typing-banner" />
 </a>
 
 <br />
@@ -21,16 +21,97 @@
 const patrick = {
   role: "Full-Stack Engineer",
   location: "Beirut, Lebanon 🇱🇧",
-  focus: ["React", "TypeScript", "Node.js", "Microservices", "DevOps"],
-  currentlyLearning: ["AI agents", "Edge runtimes", "Rust"],
-  funFact: "Worked at 6 startups across the world before graduating 🚀",
+  focus: ["React", "TypeScript", "Node.js", "React Native", "DevOps"],
+  currentlyExploring: ["AI agents", "Edge runtimes", "Rust"],
+  openSource: "Contributor to Expo, React Native, Tokio, Prettier & more",
   askMeAbout: ["scalable web apps", "system design", "shipping fast"],
 };
 ```
 
-- 🔭 I build production web apps end-to-end — from Postgres schemas to pixel-perfect UIs.
-- 🧪 Currently exploring **agentic systems**, **LLM tooling**, and **edge-deployed apps**.
+- 🔭 I build production web &amp; mobile apps end-to-end — from Postgres schemas to pixel-perfect UIs.
+- 🌍 I give back to the tools I use daily, contributing fixes across the **React Native, React, Python &amp; Rust** ecosystems.
 - 📫 Reach me at **patrick.wehbe.applications@gmail.com**
+
+---
+
+### 🌍 Open Source Contributions
+
+<div align="center">
+
+I contribute fixes and improvements upstream to the libraries I build with every day.
+
+<img src="https://img.shields.io/badge/Projects-30%2B-58A6FF?style=for-the-badge" />
+<img src="https://img.shields.io/badge/Pull_Requests-45%2B-8957E5?style=for-the-badge" />
+<img src="https://img.shields.io/badge/Merged-5_%26_counting-3FB950?style=for-the-badge" />
+
+</div>
+
+#### 🏅 Merged into upstream
+
+| Project | Contribution | PR |
+|:--|:--|:--|
+| [**tokio-rs/tokio**](https://github.com/tokio-rs/tokio) | Corrected the reversed poll-order description in the `timeout` docs | [#8214](https://github.com/tokio-rs/tokio/pull/8214) |
+| [**cli/cli**](https://github.com/cli/cli) | Fixed a dead anchor link in the release-process docs | [#13688](https://github.com/cli/cli/pull/13688) |
+| [**agronholm/anyio**](https://github.com/agronholm/anyio) | Added a missing `await` to a file-I/O concurrency example | [#1182](https://github.com/agronholm/anyio/pull/1182) |
+| [**tj/commander.js**](https://github.com/tj/commander.js) | Fixed two syntax errors in shipped JSDoc `@example` blocks | [#2536](https://github.com/tj/commander.js/pull/2536) |
+| [**software-mansion/react-native-reanimated**](https://github.com/software-mansion/react-native-reanimated) | Updated the `getRelativeCoords` example to the v4 Gesture API | [#9713](https://github.com/software-mansion/react-native-reanimated/pull/9713) |
+
+#### 📋 Contributions by ecosystem
+
+<details open>
+<summary><b>⚛️&nbsp; React Native &amp; Expo</b></summary>
+<br/>
+
+- **[expo/expo](https://github.com/expo/expo)** — fixed `findUpPackageJson` infinite recursion at the Windows drive root · [#47095](https://github.com/expo/expo/pull/47095)
+- **[expo/eas-cli](https://github.com/expo/eas-cli)** — corrected `channel:pause`/`resume` arg descriptions · [#3887](https://github.com/expo/eas-cli/pull/3887) · fixed `update:republish` description · [#3888](https://github.com/expo/eas-cli/pull/3888)
+- **[expo/orbit](https://github.com/expo/orbit)** — fixed an iOS launch error message · [#348](https://github.com/expo/orbit/pull/348)
+- **[software-mansion/react-native-svg](https://github.com/software-mansion/react-native-svg)** — added `xmlns`/`xmlnsXlink` to `SvgProps` · [#2982](https://github.com/software-mansion/react-native-svg/pull/2982) · added HTTP `headers` to `SvgUri` · [#2983](https://github.com/software-mansion/react-native-svg/pull/2983)
+- **[software-mansion/react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)** — fixed deprecated Babel plugin names + an escaped doc link · [#9714](https://github.com/software-mansion/react-native-reanimated/pull/9714)
+- **[callstack/react-native-paper](https://github.com/callstack/react-native-paper)** — forwarded the press event to a Tooltip's wrapped child · [#5010](https://github.com/callstack/react-native-paper/pull/5010)
+- **[callstack/react-native-slider](https://github.com/callstack/react-native-slider)** — declared `react`/`react-native` as peer dependencies · [#817](https://github.com/callstack/react-native-slider/pull/817)
+- **[mrousavy/react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera)** — fixed incorrect API examples in the docs · [#4030](https://github.com/mrousavy/react-native-vision-camera/pull/4030)
+- **[mrousavy/react-native-mmkv](https://github.com/mrousavy/react-native-mmkv)** — fixed README example errors · [#1073](https://github.com/mrousavy/react-native-mmkv/pull/1073)
+- **[react-native-webview/react-native-webview](https://github.com/react-native-webview/react-native-webview)** — corrected a wrong documented default + an invalid union value · [#3964](https://github.com/react-native-webview/react-native-webview/pull/3964)
+- **[react-native-elements](https://github.com/react-native-elements/react-native-elements)** — narrowed `ButtonProps` children for React 19 · [#4033](https://github.com/react-native-elements/react-native-elements/pull/4033) · aligned `ListItem` prop types · [#4034](https://github.com/react-native-elements/react-native-elements/pull/4034)
+- **[react-native-datetimepicker](https://github.com/react-native-datetimepicker/datetimepicker)** — corrected an iOS Flow prop type · [#1048](https://github.com/react-native-datetimepicker/datetimepicker/pull/1048)
+- **[lottie-react-native](https://github.com/lottie-react-native/lottie-react-native)** — fixed stale org/package references in docs · [#1430](https://github.com/lottie-react-native/lottie-react-native/pull/1430)
+- **[nativewind/nativewind](https://github.com/nativewind/nativewind)** — added Switch `thumb-*`/`track-*` · [#1826](https://github.com/nativewind/nativewind/pull/1826) · and `caret-*` color utilities · [#1827](https://github.com/nativewind/nativewind/pull/1827)
+- **[tamagui/tamagui](https://github.com/tamagui/tamagui)** — fixed a `Select.Viewport` style leak · [#4042](https://github.com/tamagui/tamagui/pull/4042) · and numeric `fontSize` line-height · [#4043](https://github.com/tamagui/tamagui/pull/4043)
+- **[gluestack/gluestack-ui](https://github.com/gluestack/gluestack-ui)** — fixed a FormControl import · [#3422](https://github.com/gluestack/gluestack-ui/pull/3422) · and an `aria-disabled` key + displayName typo · [#3423](https://github.com/gluestack/gluestack-ui/pull/3423)
+- **[pmndrs/react-spring](https://github.com/pmndrs/react-spring)** — passed an `AnimationResult` to `SpringValue` `onChange` · [#2548](https://github.com/pmndrs/react-spring/pull/2548)
+
+</details>
+
+<details>
+<summary><b>⚛️&nbsp; React (web)</b></summary>
+<br/>
+
+- **[adobe/react-spectrum](https://github.com/adobe/react-spectrum)** — Collections docs · [#10232](https://github.com/adobe/react-spectrum/pull/10232) · TableView example fix · [#10233](https://github.com/adobe/react-spectrum/pull/10233) · exported `DayOfWeek` type · [#10234](https://github.com/adobe/react-spectrum/pull/10234) · ComboBox docs · [#10222](https://github.com/adobe/react-spectrum/pull/10222)
+- **[radix-ui/primitives](https://github.com/radix-ui/primitives)** — allowed `virtualRef` to accept `RefObject<Measurable | null>` for React 19 · [#3969](https://github.com/radix-ui/primitives/pull/3969)
+- **[reactjs/react.dev](https://github.com/reactjs/react.dev)** — fixed an outdated CodeSandbox console note · [#8479](https://github.com/reactjs/react.dev/pull/8479) · updated the IE / React 18 browser-support note · [#8480](https://github.com/reactjs/react.dev/pull/8480)
+
+</details>
+
+<details>
+<summary><b>🧰&nbsp; Developer tooling &amp; libraries</b></summary>
+<br/>
+
+- **[prettier/prettier](https://github.com/prettier/prettier)** — stopped treating SCSS `!default`/`!global` inside strings as flags · [#19404](https://github.com/prettier/prettier/pull/19404)
+- **[sindresorhus/ora](https://github.com/sindresorhus/ora)** — fixed type definitions that contradicted the implementation · [#257](https://github.com/sindresorhus/ora/pull/257)
+- **[yargs/yargs](https://github.com/yargs/yargs)** — fixed broken links in `api.md` · [#2549](https://github.com/yargs/yargs/pull/2549)
+- **[cli/cli](https://github.com/cli/cli)** — fixed a broken install command + link/grammar errors · [#13690](https://github.com/cli/cli/pull/13690)
+
+</details>
+
+<details>
+<summary><b>🐍&nbsp; Python &nbsp;·&nbsp; 🦀&nbsp; Rust &nbsp;·&nbsp; 🎮&nbsp; Game tooling</b></summary>
+<br/>
+
+- **[django/asgiref](https://github.com/django/asgiref)** — wrapped `async_to_sync` with `functools.update_wrapper` · [#565](https://github.com/django/asgiref/pull/565)
+- **[rust-itertools/itertools](https://github.com/rust-itertools/itertools)** — used saturating arithmetic to avoid `usize` overflow panics · [#1109](https://github.com/rust-itertools/itertools/pull/1109)
+- **[ArchipelagoMW/Archipelago](https://github.com/ArchipelagoMW/Archipelago)** — seven fixes across the Launcher, Core, WebHost, Utils &amp; docs · [#6271](https://github.com/ArchipelagoMW/Archipelago/pull/6271) · [#6272](https://github.com/ArchipelagoMW/Archipelago/pull/6272) · [#6273](https://github.com/ArchipelagoMW/Archipelago/pull/6273) · [#6274](https://github.com/ArchipelagoMW/Archipelago/pull/6274) · docs [#6264](https://github.com/ArchipelagoMW/Archipelago/pull/6264)–[#6266](https://github.com/ArchipelagoMW/Archipelago/pull/6266)
+
+</details>
 
 ---
 
@@ -67,18 +148,6 @@ const patrick = {
   <img src="https://github-readme-activity-graph.vercel.app/graph?username=patrickwehbe&theme=react-dark&hide_border=true&bg_color=0d1117&color=c9d1d9&line=58A6FF&point=58A6FF&area=true&area_color=58A6FF" alt="activity-graph" />
 </p>
 
----
-
-### 🏆 Trophies
-
-<p align="center">
-  <a href="https://github.com/ryo-ma/github-profile-trophy">
-    <img src="https://github-profile-trophy.vercel.app/?username=patrickwehbe&theme=onedark&no-frame=true&no-bg=true&column=7&margin-w=10" alt="trophies" />
-  </a>
-</p>
-
----
-
 <div align="center">
-  <sub>⚡ <em>Talk is cheap. Show me the code.</em> — Linus Torvalds</sub>
+  <sub>💙 Building in the open from Beirut. Always happy to collaborate.</sub>
 </div>


### PR DESCRIPTION
Refines the profile README to showcase open-source contributions.

What changed:
- New "Open Source Contributions" section: a highlights table of the 5 PRs merged upstream (tokio, cli/cli, anyio, commander.js, reanimated), plus every PR (~45 across 30+ repos) grouped by ecosystem under collapsible sections so the README stays clean.
- Removed the trophy widget — its host (github-profile-trophy) currently returns HTTP 402 and renders as a broken image.
- All remaining widgets verified live (stats, top-langs, streak, activity graph, profile views, skillicons, typing banner).

Merge to publish, or close if you want changes first.
